### PR TITLE
Fix incorrect taskId type by setting it to string

### DIFF
--- a/Todoist/REST/V2/todoist_rest_v2_openapi-3.1.0.yml
+++ b/Todoist/REST/V2/todoist_rest_v2_openapi-3.1.0.yml
@@ -765,7 +765,7 @@ paths:
         - in: path
           name: taskId
           schema:
-            type: integer
+            type: string
           required: true
           description: The ID of the task to retrieve.
       responses:
@@ -928,7 +928,7 @@ paths:
         - in: path
           name: taskId
           schema:
-            type: integer
+            type: string
           required: true
           description: The ID of the task to delete.
       responses:
@@ -961,7 +961,7 @@ paths:
         - in: path
           name: taskId
           schema:
-            type: integer
+            type: string
           required: true
           description: The ID of the task to close.
       responses:
@@ -992,7 +992,7 @@ paths:
         - in: path
           name: taskId
           schema:
-            type: integer
+            type: string
           required: true
           description: The ID of the task to reopen.
       responses:


### PR DESCRIPTION
Fixed taskId type to string, aligning with the [Todoist API docs](https://developer.todoist.com/rest/v2/#tasks).